### PR TITLE
Add px to the SVG element's height

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -290,7 +290,7 @@ loadData('japan').then(function(patients) {
 
 	var resetHeight = function() {
 		svgElement.style.height =
-			document.body.clientHeight - svgElement.getBoundingClientRect().top;
+			(document.body.clientHeight - svgElement.getBoundingClientRect().top) + 'px';
 	}
 
 	var redraw = function(event) {


### PR DESCRIPTION
It seems that the Firefox does not render correctly without the unit `px`.

<img width="466" alt="image" src="https://user-images.githubusercontent.com/11028/76694594-0315d700-66b8-11ea-8529-27b2f0bab52d.png">


